### PR TITLE
docs(backend): add module docstrings and standardize documentation

### DIFF
--- a/backend/apps/__init__.py
+++ b/backend/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Application modules for the auction platform."""

--- a/backend/apps/auctions/__init__.py
+++ b/backend/apps/auctions/__init__.py
@@ -1,0 +1,1 @@
+"""Auctions application module."""

--- a/backend/apps/authentication/__init__.py
+++ b/backend/apps/authentication/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication application module."""

--- a/backend/apps/bids/__init__.py
+++ b/backend/apps/bids/__init__.py
@@ -1,0 +1,1 @@
+"""Bids application module."""

--- a/backend/apps/disputes/__init__.py
+++ b/backend/apps/disputes/__init__.py
@@ -1,0 +1,1 @@
+"""Disputes application module."""

--- a/backend/apps/escrow/__init__.py
+++ b/backend/apps/escrow/__init__.py
@@ -1,0 +1,1 @@
+"""Escrow application module."""

--- a/backend/apps/notifications/__init__.py
+++ b/backend/apps/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""Notifications application module."""

--- a/backend/apps/orders/__init__.py
+++ b/backend/apps/orders/__init__.py
@@ -1,0 +1,1 @@
+"""Orders application module."""

--- a/backend/apps/realtime/__init__.py
+++ b/backend/apps/realtime/__init__.py
@@ -1,0 +1,1 @@
+"""Realtime application module."""

--- a/backend/apps/users/__init__.py
+++ b/backend/apps/users/__init__.py
@@ -1,0 +1,1 @@
+"""Users application module."""

--- a/backend/apps/wallet/__init__.py
+++ b/backend/apps/wallet/__init__.py
@@ -1,0 +1,1 @@
+"""Wallet application module."""

--- a/backend/common/__init__.py
+++ b/backend/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common utilities, exceptions, and helpers."""

--- a/backend/common/exceptions.py
+++ b/backend/common/exceptions.py
@@ -1,1 +1,1 @@
-"""Custom Exception Handlers"""
+"""Custom exception handlers."""

--- a/backend/common/pagination.py
+++ b/backend/common/pagination.py
@@ -1,1 +1,1 @@
-"""Pagination utilities"""
+"""Pagination utilities."""

--- a/backend/common/permissions.py
+++ b/backend/common/permissions.py
@@ -1,2 +1,1 @@
-"""Custom permission classes
-"""
+"""Custom permission classes."""

--- a/backend/common/utils.py
+++ b/backend/common/utils.py
@@ -1,2 +1,1 @@
-"""Shared utility functions.
-"""
+"""Shared utility functions."""

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -1,0 +1,1 @@
+"""Application configuration modules."""

--- a/backend/config/celery_app.py
+++ b/backend/config/celery_app.py
@@ -1,3 +1,5 @@
+"""Celery application configuration for the auction platform."""
+
 from celery import Celery
 
 celery = Celery("auction_platform")

--- a/backend/config/database.py
+++ b/backend/config/database.py
@@ -1,0 +1,1 @@
+"""Database connection and session configuration."""

--- a/backend/config/logging_config.py
+++ b/backend/config/logging_config.py
@@ -55,7 +55,6 @@ LOGGING_CONFIG = {
 
 def setup_logging(app_env: str = "development") -> None:
     """Configure logging based on the application environment."""
-
     level = "DEBUG" if app_env == "development" else "INFO"
     LOGGING_CONFIG["root"]["level"] = level
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -1,3 +1,5 @@
+"""Application settings loaded from environment variables."""
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -33,10 +35,12 @@ class Settings(BaseSettings):
 
     @property
     def allowed_hosts_list(self) -> list[str]:
+        """Return allowed hosts as a list."""
         return [host.strip() for host in self.allowed_hosts.split(",")]
 
     @property
     def cors_origins_list(self) -> list[str]:
+        """Return CORS origins as a list."""
         return [origin.strip() for origin in self.cors_origins.split(",")]
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+"""Auction platform FastAPI application entry point."""
+
 import logging
 from contextlib import asynccontextmanager
 
@@ -21,6 +23,7 @@ async def lifespan(app: FastAPI):
 
     Yields:
         None: Control to the application during its runtime.
+
     """
     setup_logging(settings.app_env)
     logger.info("Application starting up...")
@@ -45,6 +48,7 @@ app.add_middleware(
 
 @app.get("/health")
 async def health():
+    """Return application health status."""
     return {
         "status": "ok",
         "app": settings.app_name,
@@ -55,6 +59,7 @@ async def health():
 
 @app.get("/api/v1/health")
 async def health_v1():
+    """Return application health status for API v1."""
     return {
         "status": "ok",
         "app": settings.app_name,

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the auction platform."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,1 @@
+"""Pytest configuration and shared fixtures."""

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,1 @@
+"""Tests for health check endpoints."""


### PR DESCRIPTION
- Add descriptive docstrings to all application module __init__.py files
- Add docstrings to configuration modules (celery_app, database, settings)
- Add module-level docstring to main.py entry point
- Add docstrings to test suite modules (tests, conftest)
- Standardize docstring formatting across common utilities (exceptions, pagination, permissions, utils)
- Add docstrings to endpoint handler functions (health, health_v1)
- Add docstrings to property methods in Settings class
- Remove trailing whitespace and fix formatting inconsistencies
- Improve code documentation for better IDE support and maintainability