### PR TITLE
Feature/application foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ build/
 # Frontend
 node_modules/
 .next/
+
+# Others
+.coverage
+.env.test

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -13,7 +13,7 @@ migration:
 		alembic revision --autogenerate -m "$(message)"
 
 test:
-		pytest tests/ -v --cov=apps --cov-report=term-missing
+		docker-compose exec app pytest tests/ --cov
 
 lint:
 	ruff check . && black --check . && isort --check-only .

--- a/backend/common/dependency.py
+++ b/backend/common/dependency.py
@@ -1,0 +1,173 @@
+"""FastAPI dependency functions for database sessions and authentication.
+
+Provides reusable ``Depends``-compatible callables that handle:
+
+- Database session lifecycle (``get_db``).
+- JWT decoding and user resolution (``get_current_user``).
+- Email-verification gate (``get_current_active_user``).
+- Role-based access guards (``require_admin``, ``require_verified_seller``).
+"""
+
+import logging
+from typing import AsyncGenerator
+
+from fastapi import Depends
+from fastapi.security import OAuth2PasswordBearer
+from jose import ExpiredSignatureError, JWTError, jwt
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.users.enums import AccountStatus, UserRole
+from apps.users.models import User
+from common.exceptions import (
+    AccountBannedException,
+    AccountSuspendedException,
+    AdminRequiredException,
+    EmailNotVerifiedException,
+    SellerRequiredException,
+    TokenExpiredException,
+    TokenInvalidException,
+    UserNotFoundException,
+)
+from config.database import AsyncSessionLocal
+from config.settings import settings
+
+logger = logging.getLogger(__name__)
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """Yield an async database session for the duration of a request.
+
+    Opens a new ``AsyncSession`` from the session factory, yields it to
+    the route handler, and ensures it is closed when the request completes
+    regardless of whether an exception was raised.
+
+    Yields:
+        An active ``AsyncSession`` bound to the application's async engine.
+
+    """
+    async with AsyncSessionLocal() as session:
+        yield session
+
+
+async def get_current_user(
+    db: AsyncSession = Depends(get_db),
+    token: str = Depends(oauth2_scheme),
+) -> User:
+    """Decode the bearer token and return the authenticated ``User``.
+
+    Validates the JWT signature and expiry, extracts the ``sub`` claim as
+    the user ID, fetches the corresponding ``User`` row, and checks that
+    the account is neither suspended nor banned.
+
+    Args:
+        db: Injected async database session from ``get_db``.
+        token: Raw JWT string extracted from the ``Authorization`` header
+            by the ``OAuth2PasswordBearer`` scheme.
+
+    Returns:
+        The authenticated and active ``User`` ORM instance.
+
+    Raises:
+        TokenExpiredException: If the token's expiry time has passed.
+        TokenInvalidException: If the token cannot be decoded, the
+            signature is invalid, or the ``sub`` claim is missing.
+        UserNotFoundException: If no user exists for the ID in the token.
+        AccountSuspendedException: If the user's account is suspended.
+        AccountBannedException: If the user's account is banned.
+
+    """
+    try:
+        payload = jwt.decode(
+            token,
+            settings.secret_key,
+            algorithms=[settings.algorithm],
+        )
+    except ExpiredSignatureError:
+        raise TokenExpiredException()
+    except JWTError:
+        raise TokenInvalidException()
+
+    user_id = payload.get("sub")
+    if not user_id:
+        raise TokenInvalidException()
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise UserNotFoundException()
+
+    if user.account_status == AccountStatus.SUSPENDED:
+        raise AccountSuspendedException()
+
+    if user.account_status == AccountStatus.BANNED:
+        raise AccountBannedException()
+
+    return user
+
+
+async def get_current_active_user(
+    current_user: User = Depends(get_current_user),
+) -> User:
+    """Ensure the authenticated user has verified their email address.
+
+    Args:
+        current_user: Injected ``User`` instance from ``get_current_user``.
+
+    Returns:
+        The same ``User`` instance if their email is verified.
+
+    Raises:
+        EmailNotVerifiedException: If the user's email has not been
+            confirmed.
+
+    """
+    if current_user.is_email_verified:
+        return current_user
+    raise EmailNotVerifiedException()
+
+
+async def require_admin(
+    current_user: User = Depends(get_current_active_user),
+) -> User:
+    """Restrict access to users with an admin or superuser role.
+
+    Args:
+        current_user: Injected ``User`` instance from
+            ``get_current_active_user``.
+
+    Returns:
+        The same ``User`` instance if they hold an admin role.
+
+    Raises:
+        AdminRequiredException: If the user's role is neither ``ADMIN``
+            nor ``SUPERUSER``.
+
+    """
+    if current_user.role in (UserRole.ADMIN, UserRole.SUPERUSER):
+        return current_user
+    raise AdminRequiredException()
+
+
+async def require_verified_seller(
+    current_user: User = Depends(get_current_active_user),
+) -> User:
+    """Restrict access to users with a verified seller profile.
+
+    Args:
+        current_user: Injected ``User`` instance from
+            ``get_current_active_user``.
+
+    Returns:
+        The same ``User`` instance if they have a verified seller profile.
+
+    Raises:
+        SellerRequiredException: If the user has no seller profile or
+            their seller profile has not been verified.
+
+    """
+    if current_user.seller_profile and current_user.seller_profile.is_verified:
+        return current_user
+    raise SellerRequiredException()

--- a/backend/common/exception_handlers.py
+++ b/backend/common/exception_handlers.py
@@ -1,0 +1,146 @@
+"""Global exception handlers for the auction platform.
+
+Registered in ``main.py``, these handlers intercept specific exception
+types raised anywhere in the application and return consistently
+formatted ``ErrorResponse`` JSON bodies.
+
+Each handler follows the same contract:
+- Accept a ``Request`` and the raised exception.
+- Build an ``ErrorResponse`` payload.
+- Return a ``JSONResponse`` with the appropriate HTTP status code.
+"""
+
+import logging
+
+from fastapi import HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from common.exceptions import AuctionPlatformException
+from common.schemas import ErrorDetail, ErrorResponse
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_auction_platform_exception(
+    request: Request,
+    exc: AuctionPlatformException,
+) -> JSONResponse:
+    """Handle any ``AuctionPlatformException`` subclass.
+
+    Serialises the exception's structured metadata directly into the
+    ``ErrorResponse`` envelope and returns it with the exception's own
+    HTTP status code.
+
+    Args:
+        request: The incoming FastAPI request (unused but required by
+            the handler signature).
+        exc: The caught ``AuctionPlatformException`` instance.
+
+    Returns:
+        A ``JSONResponse`` containing the serialised ``ErrorResponse``.
+
+    """
+    content = ErrorResponse(
+        code=exc.code,
+        status="error",
+        message=exc.message,
+        details=exc.details,
+    )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=content.model_dump(),
+    )
+
+
+async def handle_pydantic_validation_error(
+    request: Request,
+    exc: RequestValidationError,
+) -> JSONResponse:
+    """Handle Pydantic ``RequestValidationError`` raised by FastAPI.
+
+    Flattens the list of Pydantic validation errors into ``ErrorDetail``
+    objects, joining nested location parts with `` -> `` for readability.
+
+    Args:
+        request: The incoming FastAPI request (unused but required by
+            the handler signature).
+        exc: The caught ``RequestValidationError`` instance.
+
+    Returns:
+        A ``JSONResponse`` with HTTP 422 and a list of field-level errors.
+
+    """
+    error_details = []
+
+    for error in exc.errors():
+        field = " -> ".join(str(item) for item in error["loc"][1:])
+        error_details.append(ErrorDetail(field=field, message=error["msg"]))
+
+    content = ErrorResponse(
+        code="VALIDATION_ERROR",
+        status="error",
+        message="Validation failed",
+        details=error_details,
+    )
+    return JSONResponse(
+        status_code=422,
+        content=content.model_dump(),
+    )
+
+
+async def handle_not_found(
+    request: Request,
+    exc: HTTPException,
+) -> JSONResponse:
+    """Handle FastAPI ``HTTPException`` raised with a 404 status.
+
+    Args:
+        request: The incoming FastAPI request (unused but required by
+            the handler signature).
+        exc: The caught ``HTTPException`` instance.
+
+    Returns:
+        A ``JSONResponse`` with HTTP 404 and a ``NOT_FOUND`` error code.
+
+    """
+    content = ErrorResponse(
+        code="NOT_FOUND",
+        status="error",
+        message=exc.detail,
+    )
+    return JSONResponse(
+        status_code=404,
+        content=content.model_dump(),
+    )
+
+
+async def handle_generic_exception(
+    request: Request,
+    exc: Exception,
+) -> JSONResponse:
+    """Handle any unhandled exception as an internal server error.
+
+    Logs the full traceback at ERROR level so it is captured by the
+    application's logging pipeline, then returns a generic 500 response
+    without leaking internal details to the client.
+
+    Args:
+        request: The incoming FastAPI request (unused but required by
+            the handler signature).
+        exc: The unhandled exception instance.
+
+    Returns:
+        A ``JSONResponse`` with HTTP 500 and an ``INTERNAL_SERVER_ERROR``
+        error code.
+
+    """
+    logger.error("Unhandled exception", exc_info=True)
+    content = ErrorResponse(
+        code="INTERNAL_SERVER_ERROR",
+        message="An unexpected error occurred",
+    )
+    return JSONResponse(
+        status_code=500,
+        content=content.model_dump(),
+    )

--- a/backend/common/exceptions.py
+++ b/backend/common/exceptions.py
@@ -1,1 +1,362 @@
-"""Custom exception handlers."""
+"""Custom exception hierarchy for the auction platform.
+
+All application exceptions inherit from ``AuctionPlatformException``,
+which carries a machine-readable ``code``, an HTTP ``status_code``, and
+an optional list of field-level ``details``.  Callers can catch the base
+class to handle any platform error uniformly, or catch specific subclasses
+for fine-grained control.
+
+Exception groups
+----------------
+- Authentication  : credential, token, and account-state failures (401/403).
+- Authorization   : role and permission enforcement (403).
+- Not Found       : missing resource lookups (404).
+- Validation      : input and business-rule violations (409/422).
+- Conflict        : duplicate or state-conflict errors (409).
+- Financial       : wallet, escrow, and payment failures (400/500).
+"""
+
+# ---------------------------------------------------------------------------
+# Base
+# ---------------------------------------------------------------------------
+
+
+class AuctionPlatformException(Exception):  # noqa: N818
+    """Root exception for all auction platform errors.
+
+    Every domain exception inherits from this class so that a single
+    ``except AuctionPlatformException`` clause can catch any platform
+    error and serialise it into a consistent HTTP error response.
+
+    Attributes:
+        message: Human-readable description of the error.
+        code: Upper-snake-case machine-readable error identifier,
+            e.g. ``"INVALID_CREDENTIALS"``.
+        status_code: HTTP status code that should be returned to the client.
+        details: Optional list of supplementary error objects, typically
+            used for field-level validation errors.
+
+    """
+
+    def __init__(
+        self,
+        message: str,
+        code: str,
+        status_code: int,
+        details: list | None = None,
+    ) -> None:
+        """Initialise the exception with structured error metadata.
+
+        Args:
+            message: Human-readable error description.
+            code: Machine-readable error code string.
+            status_code: HTTP status code for the response.
+            details: Optional list of supplementary error detail objects.
+
+        """
+        self.message = message
+        self.code = code
+        self.status_code = status_code
+        self.details = details or []
+        super().__init__(message)
+
+
+# ---------------------------------------------------------------------------
+# Authentication  (HTTP 401 / 403)
+# ---------------------------------------------------------------------------
+
+
+class InvalidCredentialsException(AuctionPlatformException):
+    """Raised when a login attempt fails due to wrong email or password."""
+
+    def __init__(self, message: str = "Invalid credentials") -> None:
+        """Initialise with error code ``INVALID_CREDENTIALS`` and HTTP 401."""
+        super().__init__(
+            message=message,
+            code="INVALID_CREDENTIALS",
+            status_code=401,
+        )
+
+
+class TokenExpiredException(AuctionPlatformException):
+    """Raised when a JWT or session token has passed its expiry time."""
+
+    def __init__(self, message: str = "Token has expired") -> None:
+        """Initialise with error code ``TOKEN_EXPIRED`` and HTTP 401."""
+        super().__init__(message=message, code="TOKEN_EXPIRED", status_code=401)
+
+
+class TokenInvalidException(AuctionPlatformException):
+    """Raised when a token cannot be decoded or its signature is invalid."""
+
+    def __init__(self, message: str = "Token is invalid") -> None:
+        """Initialise with error code ``TOKEN_INVALID`` and HTTP 401."""
+        super().__init__(message=message, code="TOKEN_INVALID", status_code=401)
+
+
+class EmailNotVerifiedException(AuctionPlatformException):
+    """Raised when an action requires a verified email but the user has not done so.
+
+    HTTP 403 is returned since the account exists but access is restricted
+    until the email address is verified.
+    """
+
+    def __init__(self, message: str = "Email address is not verified") -> None:
+        """Initialise with error code ``EMAIL_NOT_VERIFIED`` and HTTP 403."""
+        super().__init__(message=message, code="EMAIL_NOT_VERIFIED", status_code=403)
+
+
+class AccountSuspendedException(AuctionPlatformException):
+    """Raised when a suspended account attempts an authenticated action."""
+
+    def __init__(self, message: str = "Account has been suspended") -> None:
+        """Initialise with error code ``ACCOUNT_SUSPENDED`` and HTTP 403."""
+        super().__init__(message=message, code="ACCOUNT_SUSPENDED", status_code=403)
+
+
+class AccountBannedException(AuctionPlatformException):
+    """Raised when a permanently banned account attempts an authenticated action."""
+
+    def __init__(self, message: str = "Account has been banned") -> None:
+        """Initialise with error code ``ACCOUNT_BANNED`` and HTTP 403."""
+        super().__init__(message=message, code="ACCOUNT_BANNED", status_code=403)
+
+
+# ---------------------------------------------------------------------------
+# Authorization  (HTTP 403)
+# ---------------------------------------------------------------------------
+
+
+class PermissionDeniedException(AuctionPlatformException):
+    """Raised when an authenticated user lacks the required permission."""
+
+    def __init__(self, message: str = "Permission denied") -> None:
+        """Initialise with error code ``PERMISSION_DENIED`` and HTTP 403."""
+        super().__init__(message=message, code="PERMISSION_DENIED", status_code=403)
+
+
+class AdminRequiredException(AuctionPlatformException):
+    """Raised when an endpoint is restricted to admin users only."""
+
+    def __init__(self, message: str = "Admin access required") -> None:
+        """Initialise with error code ``ADMIN_REQUIRED`` and HTTP 403."""
+        super().__init__(message=message, code="ADMIN_REQUIRED", status_code=403)
+
+
+class SellerRequiredException(AuctionPlatformException):
+    """Raised when an endpoint requires a verified seller account."""
+
+    def __init__(self, message: str = "Verified seller account required") -> None:
+        """Initialise with error code ``SELLER_REQUIRED`` and HTTP 403."""
+        super().__init__(message=message, code="SELLER_REQUIRED", status_code=403)
+
+
+# ---------------------------------------------------------------------------
+# Not Found  (HTTP 404)
+# ---------------------------------------------------------------------------
+
+
+class NotFoundException(AuctionPlatformException):
+    """Base exception for any resource that cannot be located.
+
+    Concrete subclasses supply a domain-specific ``code``; this class
+    fixes the HTTP status at 404.
+    """
+
+    def __init__(self, message: str, code: str) -> None:
+        """Initialise with the given message and code, HTTP 404.
+
+        Args:
+            message: Human-readable description of what was not found.
+            code: Machine-readable error code for the missing resource type.
+
+        """
+        super().__init__(message=message, code=code, status_code=404)
+
+
+class UserNotFoundException(NotFoundException):
+    """Raised when a user record cannot be found by the given identifier."""
+
+    def __init__(self, message: str = "User not found") -> None:
+        """Initialise with error code ``USER_NOT_FOUND``."""
+        super().__init__(message=message, code="USER_NOT_FOUND")
+
+
+class AuctionNotFoundException(NotFoundException):
+    """Raised when an auction cannot be found by the given identifier."""
+
+    def __init__(self, message: str = "Auction not found") -> None:
+        """Initialise with error code ``AUCTION_NOT_FOUND``."""
+        super().__init__(message=message, code="AUCTION_NOT_FOUND")
+
+
+class BidNotFoundException(NotFoundException):
+    """Raised when a bid cannot be found by the given identifier."""
+
+    def __init__(self, message: str = "Bid not found") -> None:
+        """Initialise with error code ``BID_NOT_FOUND``."""
+        super().__init__(message=message, code="BID_NOT_FOUND")
+
+
+class OrderNotFoundException(NotFoundException):
+    """Raised when an order cannot be found by the given identifier."""
+
+    def __init__(self, message: str = "Order not found") -> None:
+        """Initialise with error code ``ORDER_NOT_FOUND``."""
+        super().__init__(message=message, code="ORDER_NOT_FOUND")
+
+
+class WalletNotFoundException(NotFoundException):
+    """Raised when a wallet cannot be found for the given user."""
+
+    def __init__(self, message: str = "Wallet not found") -> None:
+        """Initialise with error code ``WALLET_NOT_FOUND``."""
+        super().__init__(message=message, code="WALLET_NOT_FOUND")
+
+
+# ---------------------------------------------------------------------------
+# Validation  (HTTP 422)
+# ---------------------------------------------------------------------------
+
+
+class ValidationException(AuctionPlatformException):
+    """Raised when request input fails schema or business-rule validation.
+
+    Accepts an optional ``details`` list to carry field-level error
+    information back to the client.
+    """
+
+    def __init__(
+        self,
+        message: str = "Validation failed",
+        details: list | None = None,
+    ) -> None:
+        """Initialise with error code ``VALIDATION_ERROR`` and HTTP 422.
+
+        Args:
+            message: Summary of the validation failure.
+            details: Optional list of field-level error detail objects.
+
+        """
+        super().__init__(
+            message=message,
+            code="VALIDATION_ERROR",
+            status_code=422,
+            details=details,
+        )
+
+
+class InsufficientFundsException(AuctionPlatformException):
+    """Raised when a user's available balance is too low for the operation."""
+
+    def __init__(self, message: str = "Insufficient funds") -> None:
+        """Initialise with error code ``INSUFFICIENT_FUNDS`` and HTTP 422."""
+        super().__init__(message=message, code="INSUFFICIENT_FUNDS", status_code=422)
+
+
+class InvalidBidAmountException(AuctionPlatformException):
+    """Raised when a bid amount does not meet the auction's minimum increment."""
+
+    def __init__(self, message: str = "Invalid bid amount") -> None:
+        """Initialise with error code ``INVALID_BID_AMOUNT`` and HTTP 422."""
+        super().__init__(message=message, code="INVALID_BID_AMOUNT", status_code=422)
+
+
+# ---------------------------------------------------------------------------
+# Conflict  (HTTP 409)
+# ---------------------------------------------------------------------------
+
+
+class AuctionNotActiveException(AuctionPlatformException):
+    """Raised when an action requires an active auction but it is not active."""
+
+    def __init__(self, message: str = "Auction is not active") -> None:
+        """Initialise with error code ``AUCTION_NOT_ACTIVE`` and HTTP 409."""
+        super().__init__(message=message, code="AUCTION_NOT_ACTIVE", status_code=409)
+
+
+class AuctionEndedException(AuctionPlatformException):
+    """Raised when an action is attempted on an auction that has already ended."""
+
+    def __init__(self, message: str = "Auction has ended") -> None:
+        """Initialise with error code ``AUCTION_ENDED`` and HTTP 409."""
+        super().__init__(message=message, code="AUCTION_ENDED", status_code=409)
+
+
+class AlreadyExistsException(AuctionPlatformException):
+    """Raised when attempting to create a resource that already exists."""
+
+    def __init__(self, message: str = "Resource already exists") -> None:
+        """Initialise with error code ``ALREADY_EXISTS`` and HTTP 409."""
+        super().__init__(message=message, code="ALREADY_EXISTS", status_code=409)
+
+
+class AlreadyHighestBidderException(AuctionPlatformException):
+    """Raised when a user bids again while already holding the highest bid."""
+
+    def __init__(self, message: str = "You are already the highest bidder") -> None:
+        """Initialise with error code ``ALREADY_HIGHEST_BIDDER`` and HTTP 409."""
+        super().__init__(
+            message=message, code="ALREADY_HIGHEST_BIDDER", status_code=409
+        )
+
+
+class SellerCannotBidException(AuctionPlatformException):
+    """Raised when a seller attempts to bid on their own auction."""
+
+    def __init__(
+        self, message: str = "Sellers cannot bid on their own auctions"
+    ) -> None:
+        """Initialise with error code ``SELLER_CANNOT_BID`` and HTTP 409."""
+        super().__init__(message=message, code="SELLER_CANNOT_BID", status_code=409)
+
+
+class DisputeAlreadyExistsException(AuctionPlatformException):
+    """Raised when a dispute is opened for an order that already has one."""
+
+    def __init__(
+        self, message: str = "A dispute already exists for this order"
+    ) -> None:
+        """Initialise with error code ``DISPUTE_ALREADY_EXISTS`` and HTTP 409."""
+        super().__init__(
+            message=message, code="DISPUTE_ALREADY_EXISTS", status_code=409
+        )
+
+
+# ---------------------------------------------------------------------------
+# Financial  (HTTP 400 / 500)
+# ---------------------------------------------------------------------------
+
+
+class WalletLockException(AuctionPlatformException):
+    """Raised when the system fails to lock funds in a user's wallet.
+
+    Typically indicates a concurrency issue or an unexpected database error
+    during the fund-locking step of the bid or checkout flow.
+    """
+
+    def __init__(self, message: str = "Failed to lock wallet funds") -> None:
+        """Initialise with error code ``WALLET_LOCK_FAILED`` and HTTP 500."""
+        super().__init__(message=message, code="WALLET_LOCK_FAILED", status_code=500)
+
+
+class EscrowCreationException(AuctionPlatformException):
+    """Raised when the system fails to create an escrow record for an order."""
+
+    def __init__(self, message: str = "Failed to create escrow") -> None:
+        """Initialise with error code ``ESCROW_CREATION_FAILED`` and HTTP 500."""
+        super().__init__(
+            message=message, code="ESCROW_CREATION_FAILED", status_code=500
+        )
+
+
+class PaymentVerificationException(AuctionPlatformException):
+    """Raised when a payment gateway callback cannot be verified."""
+
+    def __init__(self, message: str = "Payment verification failed") -> None:
+        """Initialise with error code ``PAYMENT_VERIFICATION_FAILED`` and HTTP 400."""
+        super().__init__(
+            message=message,
+            code="PAYMENT_VERIFICATION_FAILED",
+            status_code=400,
+        )

--- a/backend/common/middleware.py
+++ b/backend/common/middleware.py
@@ -13,6 +13,7 @@ from typing import Callable
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,26 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         )
 
         start_time = time.time()
-        response = await call_next(request)
+        try:
+            response = await call_next(request)
+        except Exception:
+            process_time = (time.time() - start_time) * 1000
+            logger.error(
+                "Request failed | request_id=%s duration_ms=%.2f",
+                request_id,
+                process_time,
+                exc_info=True,
+            )
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "status": "error",
+                    "code": "INTERNAL_SERVER_ERROR",
+                    "message": "An unexpected error occurred",
+                    "details": [],
+                },
+                headers={"X-Request-ID": request_id},
+            )
 
         response.headers["X-Request-ID"] = request_id
 

--- a/backend/common/middleware.py
+++ b/backend/common/middleware.py
@@ -1,0 +1,69 @@
+"""Custom Starlette middleware for the auction platform.
+
+Currently provides:
+- ``RequestLoggingMiddleware``: logs every inbound request and its
+  completed response, attaching a unique ``X-Request-ID`` header for
+  distributed tracing.
+"""
+
+import logging
+import time
+import uuid
+from typing import Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+logger = logging.getLogger(__name__)
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Middleware that logs request/response details and injects a request ID.
+
+    For every HTTP request the middleware:
+
+    1. Reads the ``X-Request-ID`` header if present, or generates a new
+       UUID4 to use as the request identifier.
+    2. Logs the incoming request (method, path, client IP, request ID).
+    3. Delegates to the next handler via ``call_next``.
+    4. Attaches the request ID to the response as ``X-Request-ID``.
+    5. Logs the completed response (status code, duration in ms).
+    """
+
+    async def dispatch(self, request: Request, call_next: Callable):
+        """Process a single request, adding logging and a request ID.
+
+        Args:
+            request: The incoming Starlette ``Request`` object.
+            call_next: Callable that forwards the request to the next
+                middleware or route handler and returns the response.
+
+        Returns:
+            The ``Response`` returned by the downstream handler, with the
+            ``X-Request-ID`` header added.
+
+        """
+        request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+
+        logger.info(
+            "Request started | request_id=%s method=%s path=%s client_ip=%s",
+            request_id,
+            request.method,
+            request.url.path,
+            request.client.host,
+        )
+
+        start_time = time.time()
+        response = await call_next(request)
+
+        response.headers["X-Request-ID"] = request_id
+
+        process_time = (time.time() - start_time) * 1000
+        logger.info(
+            "Request completed | request_id=%s status_code=%s duration_ms=%.2f",
+            request_id,
+            response.status_code,
+            process_time,
+        )
+
+        return response

--- a/backend/common/pagination.py
+++ b/backend/common/pagination.py
@@ -1,1 +1,80 @@
-"""Pagination utilities."""
+"""Pagination utilities for SQLAlchemy async queries.
+
+Provides a ``PageParams`` schema for validating page/limit query parameters
+and a ``paginate`` helper that executes a count query and a data query,
+returning a fully populated ``PaginatedResponse``.
+"""
+
+import math
+
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from common.schemas import PaginatedResponse, PaginationMeta
+
+
+class PageParams(BaseModel):
+    """Query parameters for paginated list endpoints.
+
+    Attributes:
+        page: The requested page number, 1-indexed. Must be >= 1.
+        limit: Maximum number of items to return per page.
+            Clamped between 1 and 100.
+
+    """
+
+    page: int = Field(default=1, ge=1)
+    limit: int = Field(default=20, ge=1, le=100)
+
+
+async def paginate(
+    query,
+    page: int,
+    limit: int,
+    session: AsyncSession,
+) -> PaginatedResponse:
+    """Execute a paginated SQLAlchemy query and return a structured response.
+
+    Runs two database operations against the provided async session:
+
+    1. A ``COUNT(*)`` wrapped around the original query as a subquery to
+       determine the total number of matching rows.
+    2. The original query with ``OFFSET`` and ``LIMIT`` applied to fetch
+       the current page of results.
+
+    Args:
+        query: A SQLAlchemy ``Select`` statement to paginate. Must be
+            compatible with ``.subquery()`` for the count step.
+        page: The 1-indexed page number to retrieve.
+        limit: Maximum number of rows to return for this page.
+        session: An active ``AsyncSession`` used to execute both queries.
+
+    Returns:
+        A ``PaginatedResponse`` containing the serialised items for the
+        requested page and a ``PaginationMeta`` object describing the
+        full pagination state.
+
+    """
+    offset = (page - 1) * limit
+
+    count_query = select(func.count()).select_from(query.subquery())
+    total = await session.scalar(count_query)
+
+    result = await session.execute(query.offset(offset).limit(limit))
+    items = result.scalars().all()
+
+    total_pages = math.ceil(total / limit) if total > 0 else 1
+
+    return PaginatedResponse(
+        message="OK",
+        data=items,
+        pagination=PaginationMeta(
+            page=page,
+            limit=limit,
+            total=total,
+            total_pages=total_pages,
+            has_next=page < total_pages,
+            has_previous=page > 1,
+        ),
+    )

--- a/backend/common/schemas.py
+++ b/backend/common/schemas.py
@@ -1,0 +1,92 @@
+"""Shared Pydantic schema models used across the application.
+
+Provides reusable response and error structures that are referenced by
+multiple apps rather than belonging to any single domain module.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class ErrorDetail(BaseModel):
+    """A single field-level error detail returned in validation responses.
+
+    Attributes:
+        field: The name of the input field that failed validation.
+        message: Human-readable explanation of why the field is invalid.
+
+    """
+
+    field: str
+    message: str
+
+
+class ErrorResponse(BaseModel):
+    """Standard error envelope returned by all API error handlers.
+
+    Attributes:
+        code: Machine-readable upper-snake-case error identifier.
+        message: Human-readable summary of the error.
+        details: Optional list of field-level ``ErrorDetail`` objects,
+            populated for validation errors.
+
+    """
+
+    code: str
+    status: Literal["error"] = "error"
+    message: str
+    details: list[ErrorDetail] = []
+
+
+class SuccessResponse(BaseModel):
+    """Standard success envelope returned by all API success handlers.
+
+    Attributes:
+        status: Always ``"success"`` as a convenience discriminator for clients.
+        message: Human-readable description of the completed operation.
+        data: The JSON-serializable response payload, or ``None``.
+
+    """
+
+    status: Literal["success"] = "success"
+    message: str
+    data: Any | None = None
+
+
+class PaginationMeta(BaseModel):
+    """Metadata describing the current pagination state of a list response.
+
+    Attributes:
+        page: The current page number (1-indexed).
+        limit: Maximum number of items returned per page.
+        total: Total number of items across all pages.
+        total_pages: Total number of pages given the current limit.
+        has_next: Whether a next page exists.
+        has_previous: Whether a previous page exists.
+
+    """
+
+    page: int
+    limit: int
+    total: int
+    total_pages: int
+    has_next: bool
+    has_previous: bool
+
+
+class PaginatedResponse(BaseModel):
+    """Standard paginated response envelope.
+
+    Attributes:
+        status: Always ``"success"`` as a convenience discriminator for clients.
+        message: Human-readable description of the completed operation.
+        data: The JSON-serializable list of items for the current page.
+        pagination: Metadata describing the current pagination state.
+
+    """
+
+    status: Literal["success"] = "success"
+    message: str
+    data: list[Any]
+    pagination: PaginationMeta

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -29,6 +29,9 @@ class Settings(BaseSettings):
     # Hosts
     allowed_hosts: str = "localhost,127.0.0.1"
 
+    # Algorithms
+    algorithm: str
+
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", case_sensitive=False
     )

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ from common.exception_handlers import (
     handle_pydantic_validation_error,
 )
 from common.exceptions import AuctionPlatformException
+from common.middleware import RequestLoggingMiddleware
 from config.logging_config import setup_logging
 from config.settings import settings
 
@@ -44,6 +45,8 @@ app = FastAPI(
     version=settings.app_version,
     lifespan=lifespan,
 )
+
+app.add_middleware(RequestLoggingMiddleware)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,9 +3,11 @@
 import logging
 from contextlib import asynccontextmanager
 
+import redis.asyncio as aioredis
 from fastapi import FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import text
 
 from common.exception_handlers import (
     handle_auction_platform_exception,
@@ -15,6 +17,7 @@ from common.exception_handlers import (
 )
 from common.exceptions import AuctionPlatformException
 from common.middleware import RequestLoggingMiddleware
+from config.database import engine
 from config.logging_config import setup_logging
 from config.settings import settings
 
@@ -35,19 +38,48 @@ async def lifespan(app: FastAPI):
 
     """
     setup_logging(settings.app_env)
-    logger.info("Application starting up...")
+    logger.info(
+        "Starting %s v%s [%s]",
+        settings.app_name,
+        settings.app_version,
+        settings.app_env,
+    )
+
+    # Verify database connection
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        logger.info("Database connection verified")
+    except Exception:
+        logger.error("Database connection failed", exc_info=True)
+
+    # Verify Redis connection
+    try:
+        redis_client = aioredis.from_url(settings.redis_url)
+        await redis_client.ping()
+        await redis_client.aclose()
+        logger.info("Redis connection verified")
+    except Exception:
+        logger.error("Redis connection failed", exc_info=True)
+
     yield
-    logger.info("Application shutting down")
+
+    # Shutdown
+    logger.info("Shutting down %s", settings.app_name)
+    await engine.dispose()
 
 
 app = FastAPI(
     title=settings.app_name,
     version=settings.app_version,
     lifespan=lifespan,
+    docs_url="/api/docs" if settings.app_env != "production" else None,
+    redoc_url="/api/redoc" if settings.app_env != "production" else None,
+    openapi_url="/api/openapi.json" if settings.app_env != "production" else None,
 )
 
+# --- Middleware ---
 app.add_middleware(RequestLoggingMiddleware)
-
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins_list,
@@ -55,10 +87,33 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# --- Exception handlers ---
 app.add_exception_handler(AuctionPlatformException, handle_auction_platform_exception)
 app.add_exception_handler(RequestValidationError, handle_pydantic_validation_error)
 app.add_exception_handler(HTTPException, handle_not_found)
 app.add_exception_handler(Exception, handle_generic_exception)
+
+
+async def _check_db() -> bool:
+    """Return True if the database is reachable."""
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        return False
+
+
+async def _check_redis() -> bool:
+    """Return True if Redis is reachable."""
+    try:
+        redis_client = aioredis.from_url(settings.redis_url)
+        await redis_client.ping()
+        await redis_client.aclose()
+        return True
+    except Exception:
+        return False
 
 
 @app.get("/health")
@@ -69,6 +124,8 @@ async def health():
         "app": settings.app_name,
         "version": settings.app_version,
         "environment": settings.app_env,
+        "database_connected": await _check_db(),
+        "redis_connected": await _check_redis(),
     }
 
 
@@ -80,4 +137,6 @@ async def health_v1():
         "app": settings.app_name,
         "version": settings.app_version,
         "environment": settings.app_env,
+        "database_connected": await _check_db(),
+        "redis_connected": await _check_redis(),
     }

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,9 +3,17 @@
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 
+from common.exception_handlers import (
+    handle_auction_platform_exception,
+    handle_generic_exception,
+    handle_not_found,
+    handle_pydantic_validation_error,
+)
+from common.exceptions import AuctionPlatformException
 from config.logging_config import setup_logging
 from config.settings import settings
 
@@ -44,6 +52,10 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_exception_handler(AuctionPlatformException, handle_auction_platform_exception)
+app.add_exception_handler(RequestValidationError, handle_pydantic_validation_error)
+app.add_exception_handler(HTTPException, handle_not_found)
+app.add_exception_handler(Exception, handle_generic_exception)
 
 
 @app.get("/health")

--- a/backend/tests/common/__init__.py
+++ b/backend/tests/common/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for common application utilities and exception handlers."""

--- a/backend/tests/common/test_exception.py
+++ b/backend/tests/common/test_exception.py
@@ -1,0 +1,63 @@
+"""Tests for global exception handlers.
+
+Registers temporary routes on the live ``app`` instance that deliberately
+raise specific exceptions, then asserts that the global handlers return
+the correct HTTP status codes and ``ErrorResponse`` payloads.
+"""
+
+from fastapi import APIRouter
+
+from common.exceptions import AuctionNotFoundException, InsufficientFundsException
+from main import app
+
+# Temporary router used only within this test module to trigger exceptions.
+test_router = APIRouter()
+
+
+@test_router.get("/test/auction-not-found")
+async def raise_auction_not_found():
+    """Raise ``AuctionNotFoundException`` to exercise the 404 handler."""
+    raise AuctionNotFoundException()
+
+
+@test_router.get("/test/insufficient-funds")
+async def raise_insufficient_funds():
+    """Raise ``InsufficientFundsException`` to exercise the 422 handler."""
+    raise InsufficientFundsException()
+
+
+@test_router.get("/test/unhandled")
+async def raise_unhandled():
+    """Raise a bare ``RuntimeError`` to exercise the generic 500 handler."""
+    raise RuntimeError("something broke internally")
+
+
+app.include_router(test_router)
+
+
+async def test_auction_not_found_returns_404(client):
+    """AuctionNotFoundException should produce a 404 with AUCTION_NOT_FOUND code."""
+    response = await client.get("/test/auction-not-found")
+    assert response.status_code == 404
+    data = response.json()
+    assert data["status"] == "error"
+    assert data["code"] == "AUCTION_NOT_FOUND"
+
+
+async def test_insufficient_funds_returns_422(client):
+    """InsufficientFundsException should produce a 422 with INSUFFICIENT_FUNDS code."""
+    response = await client.get("/test/insufficient-funds")
+    assert response.status_code == 422
+    data = response.json()
+    assert data["status"] == "error"
+    assert data["code"] == "INSUFFICIENT_FUNDS"
+
+
+async def test_unhandled_exception_returns_500(client):
+    """Unhandled exceptions should produce a 500 without leaking internal details."""
+    response = await client.get("/test/unhandled")
+    assert response.status_code == 500
+    data = response.json()
+    assert data["status"] == "error"
+    assert data["code"] == "INTERNAL_SERVER_ERROR"
+    assert "something broke internally" not in data["message"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,1 +1,63 @@
-"""Pytest configuration and shared fixtures."""
+"""Pytest configuration and shared fixtures.
+
+Provides an async database session that rolls back after each test and
+an ``AsyncClient`` wired to the FastAPI app with the DB dependency
+overridden to use that session.
+"""
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from common.dependency import get_db
+from config.database import engine
+from main import app
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    """Provide a transactional DB session that rolls back after each test.
+
+    Opens a connection, begins a transaction, and yields an ``AsyncSession``
+    bound to that connection.  After the test completes the transaction is
+    rolled back, leaving the database in its original state.
+
+    Yields:
+        An ``AsyncSession`` scoped to a single test transaction.
+
+    """
+    async with engine.begin() as conn:
+        async with AsyncSession(bind=conn, expire_on_commit=False) as session:
+            yield session
+            await conn.rollback()
+
+
+@pytest_asyncio.fixture
+async def client(db_session):
+    """Yield an async HTTP client backed by the FastAPI app.
+
+    Overrides the ``get_db`` dependency so every request within the test
+    uses the transactional ``db_session`` fixture, ensuring database
+    operations are isolated and rolled back after each test.
+
+    Args:
+        db_session: The transactional ``AsyncSession`` fixture.
+
+    Yields:
+        An ``AsyncClient`` configured to call the FastAPI app directly
+        via ``ASGITransport``.
+
+    """
+
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as ac:
+        yield ac
+
+    app.dependency_overrides.clear()

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,1 +1,28 @@
 """Tests for health check endpoints."""
+
+
+async def test_health_returns_200(client):
+    """GET /health should return HTTP 200."""
+    response = await client.get("/health")
+    assert response.status_code == 200
+
+
+async def test_health_contains_app_name(client):
+    """GET /health response body should include the app name."""
+    response = await client.get("/health")
+    data = response.json()
+    assert data["app"] == "auction-platform"
+
+
+async def test_health_contains_status(client):
+    """GET /health response body should report status 'ok'."""
+    response = await client.get("/health")
+    data = response.json()
+    assert data["status"] == "ok"
+
+
+async def test_health_database_connected(client):
+    """GET /health response body should include a database_connected field."""
+    response = await client.get("/health")
+    data = response.json()
+    assert "database_connected" in data


### PR DESCRIPTION
## Summary

Establishes the application foundation that every feature module will build on. This PR defines the patterns for error handling, request formatting, middleware, authentication, and testing that remain consistent across all 10 feature modules.

---

## Changes

### Exception Hierarchy (`common/exceptions.py`)
Defined a custom exception hierarchy rooted at `AuctionPlatformException`. All exceptions carry `message`, `code`, `status_code`, and `details`. Grouped into:
- Authentication — `InvalidCredentialsException`, `TokenExpiredException`, `TokenInvalidException`, etc.
- Authorization — `PermissionDeniedException`, `AdminRequiredException`, `SellerRequiredException`
- Resource — `NotFoundException` and subclasses (`UserNotFoundException`, `AuctionNotFoundException`, etc.)
- Validation — `ValidationException`, `InsufficientFundsException`, `InvalidBidAmountException`, etc.
- Conflict — `AlreadyExistsException`, `SellerCannotBidException`, `DisputeAlreadyExistsException`, etc.
- Financial — `WalletLockException`, `EscrowCreationException`, `PaymentVerificationException`

### Standard Response Schemas (`common/schemas.py`)
Pydantic models defining the uniform response envelope for all API responses:
- `ErrorResponse` — status, code, message, details
- `ErrorDetail` — field-level validation error
- `SuccessResponse` — status, message, data
- `PaginatedResponse` — status, message, data list, pagination metadata
- `PaginationMeta` — page, limit, total, total_pages, has_next, has_previous

### Global Exception Handlers (`common/exception_handlers.py`)
Four handlers registered in `main.py` that intercept exceptions app-wide:
- `handle_auction_platform_exception` — catches all custom exceptions, returns `ErrorResponse` with correct status code
- `handle_pydantic_validation_error` — catches `RequestValidationError`, extracts field-level errors
- `handle_not_found` — catches `HTTPException`, returns consistent 404 format
- `handle_generic_exception` — catches all unhandled exceptions, logs full traceback, returns generic 500

### Request Logging Middleware (`common/middleware.py`)
`RequestLoggingMiddleware` wraps every request:
- Generates a unique `request_id` (UUID4) per request
- Logs method, path, client IP on incoming request
- Logs status code and duration (ms) on outgoing response
- Adds `X-Request-ID` header to every response for request tracing

### Pagination Utility (`common/pagination.py`)
- `PageParams` — Pydantic model for `?page` and `?limit` query params with validation constraints
- `paginate()` — async function that runs count + data queries and returns `PaginatedResponse` with full metadata

### Authentication Dependencies (`common/dependency.py`)
FastAPI dependency chain for authentication and authorisation:
- `get_db()` — yields async DB session per request
- `get_current_user()` — decodes JWT, fetches user, checks account status
- `get_current_active_user()` — extends above with email verification check
- `require_admin()` — restricts to ADMIN and SUPERUSER roles
- `require_verified_seller()` — restricts to verified seller accounts

### main.py Updates
- Docs URLs disabled in production environment
- Lifespan verifies DB and Redis connectivity on startup
- Health endpoints (`/health`, `/api/v1/health`) return live `database_connected` and `redis_connected` status
- All middleware, exception handlers registered in correct order
- Commented router mounting section ready for feature modules

### Tests (`tests/`)
- `conftest.py` — async `httpx` client fixture, test DB session fixture with transaction rollback, `get_db` dependency override
- `test_health.py` — 4 tests covering status code, response shape, app name, DB connectivity key
- `common/test_exceptions.py` — 3 tests verifying exception handlers return correct status codes, error codes, and don't expose internal details

---

## How to test

```bash
# Run all tests
make test

# Start the app and hit the health endpoint
docker-compose up
curl http://localhost:8000/health