### PR TITLE
chore(railway): remove explicit start command from deployment config

### DIFF
--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -3,6 +3,5 @@ builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "bash start.sh"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10


### PR DESCRIPTION
- Remove startCommand from Railway deployment configuration
- Allow Railway to use default container entrypoint instead
- Simplifies deployment configuration by relying on Dockerfile CMD directive