### PR TITLE
chore(scripts): ensure model registry is loaded in superuser creation…

### DIFF
--- a/backend/scripts/create_superuser.py
+++ b/backend/scripts/create_superuser.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 sys.path.insert(0, ".")
 
+import config.model_registry  # noqa: F401
 from apps.users.enums import AccountStatus, UserRole
 from apps.users.models import User, UserProfile
 from config.database import engine


### PR DESCRIPTION
… script

- Import config.model_registry to initialize SQLAlchemy models before database operations
- Prevents potential model registration issues during superuser creation
- Follows pattern of explicit model initialization for database scripts