### PR TITLE
feat(email): migrate from Resend to Brevo HTTP API

### DIFF
--- a/backend/common/email.py
+++ b/backend/common/email.py
@@ -1,21 +1,19 @@
-"""Email utilities using Resend HTTP API.
+"""Email utilities using Brevo (Sendinblue) HTTP API.
 
-Provides centralized email sending functionality via Resend,
-which works on platforms that block outbound SMTP (e.g. Railway).
+Sends email via Brevo's transactional API over HTTPS,
+avoiding SMTP port restrictions on platforms like Railway.
 """
 
 import logging
 from typing import List
 
-import resend
+import httpx
 
 from config.settings import settings
 
 logger = logging.getLogger(__name__)
 
-
-def _init_resend() -> None:
-    resend.api_key = settings.resend_api_key
+BREVO_API_URL = "https://api.brevo.com/v3/smtp/email"
 
 
 async def send_email(
@@ -24,7 +22,7 @@ async def send_email(
     body: str,
     subtype: str = "plain",
 ) -> None:
-    """Send an email via Resend HTTP API.
+    """Send an email via Brevo HTTP API.
 
     Args:
         subject: Email subject line
@@ -36,22 +34,30 @@ async def send_email(
         Exception: If email sending fails
 
     """
-    _init_resend()
-
     logger.info("Sending email to %s (subject: %s)", recipients, subject)
 
-    try:
-        params = {
-            "from": f"{settings.mail_from_name} <{settings.mail_from}>",
-            "to": recipients,
-            "subject": subject,
-        }
-        if subtype == "html":
-            params["html"] = body
-        else:
-            params["text"] = body
+    payload = {
+        "sender": {"name": settings.mail_from_name, "email": settings.mail_from},
+        "to": [{"email": r} for r in recipients],
+        "subject": subject,
+    }
+    if subtype == "html":
+        payload["htmlContent"] = body
+    else:
+        payload["textContent"] = body
 
-        resend.Emails.send(params)
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                BREVO_API_URL,
+                json=payload,
+                headers={
+                    "api-key": settings.brevo_api_key,
+                    "Content-Type": "application/json",
+                },
+                timeout=10,
+            )
+            response.raise_for_status()
         logger.info("Email sent successfully to %s", recipients)
     except Exception as exc:
         logger.error("Failed to send email to %s: %s", recipients, exc)
@@ -63,7 +69,7 @@ async def send_html_email(
     recipients: List[str],
     html_body: str,
 ) -> None:
-    """Send an HTML email via Resend."""
+    """Send an HTML email via Brevo."""
     await send_email(
         subject=subject,
         recipients=recipients,

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -50,6 +50,9 @@ class Settings(BaseSettings):
     # --- Resend ---
     resend_api_key: str = ""
 
+    # --- Brevo ---
+    brevo_api_key: str = ""
+
     # --- Flutterwave ---
     flutterwave_secret_key: str = ""
     flutterwave_public_key: str = ""  # You'll need this for frontend integration later


### PR DESCRIPTION
- Replace Resend SDK with httpx for direct HTTP API calls to Brevo
- Update email payload structure to match Brevo's transactional API format
- Change sender format from string to object with name and email fields
- Convert recipient list to array of email objects for Brevo compatibility
- Update content fields from html/text to htmlContent/textContent
- Add BREVO_API_URL constant for API endpoint configuration
- Remove _init_resend() function and inline API key handling
- Add brevo_api_key configuration setting to Settings class
- Improve error handling with response.raise_for_status() for HTTP errors
- Add 10-second timeout to HTTP requests for reliability
- Update docstrings and comments to reference Brevo instead of Resend
- Maintains compatibility with Railway and other platforms blocking SMTP