### PR TITLE
feat(email): migrate from Brevo to FastAPI-Mail SMTP

### DIFF
--- a/backend/common/email.py
+++ b/backend/common/email.py
@@ -1,63 +1,68 @@
-"""Email utilities using Brevo (Sendinblue) HTTP API.
+"""Email utilities using FastAPI-Mail.
 
-Sends email via Brevo's transactional API over HTTPS,
-avoiding SMTP port restrictions on platforms like Railway.
+Provides centralized email configuration and sending functionality.
+Supports both development (Mailtrap) and production SMTP servers.
 """
 
 import logging
 from typing import List
 
-import httpx
+from fastapi_mail import ConnectionConfig, FastMail, MessageSchema, MessageType
 
 from config.settings import settings
 
 logger = logging.getLogger(__name__)
 
-BREVO_API_URL = "https://api.brevo.com/v3/smtp/email"
+
+def get_mail_config() -> ConnectionConfig:
+    """Create FastAPI-Mail connection configuration from settings."""
+    validate_certs = not settings.mail_server.endswith("mailtrap.io")
+
+    return ConnectionConfig(
+        MAIL_USERNAME=settings.mail_username,
+        MAIL_PASSWORD=settings.mail_password,
+        MAIL_FROM=settings.mail_from,
+        MAIL_PORT=settings.mail_port,
+        MAIL_SERVER=settings.mail_server,
+        MAIL_FROM_NAME=settings.mail_from_name,
+        MAIL_STARTTLS=settings.mail_starttls,
+        MAIL_SSL_TLS=settings.mail_ssl_tls,
+        USE_CREDENTIALS=True,
+        VALIDATE_CERTS=validate_certs,
+    )
+
+
+def get_mail_client() -> FastMail:
+    """Get configured FastMail client instance."""
+    return FastMail(get_mail_config())
 
 
 async def send_email(
     subject: str,
     recipients: List[str],
     body: str,
-    subtype: str = "plain",
+    subtype: MessageType = MessageType.plain,
 ) -> None:
-    """Send an email via Brevo HTTP API.
+    """Send an email using configured SMTP settings."""
+    message = MessageSchema(
+        subject=subject,
+        recipients=recipients,
+        body=body,
+        subtype=subtype,
+    )
 
-    Args:
-        subject: Email subject line
-        recipients: List of recipient email addresses
-        body: Email body content
-        subtype: 'plain' or 'html'
+    fm = get_mail_client()
 
-    Raises:
-        Exception: If email sending fails
-
-    """
-    logger.info("Sending email to %s (subject: %s)", recipients, subject)
-
-    payload = {
-        "sender": {"name": settings.mail_from_name, "email": settings.mail_from},
-        "to": [{"email": r} for r in recipients],
-        "subject": subject,
-    }
-    if subtype == "html":
-        payload["htmlContent"] = body
-    else:
-        payload["textContent"] = body
+    logger.info(
+        "Sending email to %s via %s:%s (subject: %s)",
+        recipients,
+        settings.mail_server,
+        settings.mail_port,
+        subject,
+    )
 
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                BREVO_API_URL,
-                json=payload,
-                headers={
-                    "api-key": settings.brevo_api_key,
-                    "Content-Type": "application/json",
-                },
-                timeout=10,
-            )
-            response.raise_for_status()
+        await fm.send_message(message)
         logger.info("Email sent successfully to %s", recipients)
     except Exception as exc:
         logger.error("Failed to send email to %s: %s", recipients, exc)
@@ -69,10 +74,10 @@ async def send_html_email(
     recipients: List[str],
     html_body: str,
 ) -> None:
-    """Send an HTML email via Brevo."""
+    """Send an HTML email."""
     await send_email(
         subject=subject,
         recipients=recipients,
         body=html_body,
-        subtype="html",
+        subtype=MessageType.html,
     )

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -38,14 +38,14 @@ class Settings(BaseSettings):
     allowed_hosts: str = "localhost,127.0.0.1"
 
     # --- Email (SMTP) ---
-    mail_username: str = ""
-    mail_password: str = ""
-    mail_from: str = "noreply@resend.dev"
-    mail_port: int = 465
-    mail_server: str = "smtp.resend.com"
+    mail_username: str
+    mail_password: str
+    mail_from: str = "noreply@auction-platform.com"
+    mail_port: int
+    mail_server: str
     mail_from_name: str = "Auction Platform"
-    mail_starttls: bool = False
-    mail_ssl_tls: bool = True
+    mail_starttls: bool = True
+    mail_ssl_tls: bool = False
 
     # --- Resend ---
     resend_api_key: str = ""

--- a/frontend/src/pages/auctions/AuctionDetailPage.jsx
+++ b/frontend/src/pages/auctions/AuctionDetailPage.jsx
@@ -663,6 +663,40 @@ export default function AuctionDetailPage() {
                                     <div className="adp__place-bid" id="place-bid-section">
                                         <div className="adp__place-bid-title">Place Your Bid</div>
 
+                                        {/* Seller cannot bid on their own auction */}
+                                        {user?.id === seller?.id ? (
+                                            <div style={{
+                                                padding: '0.75rem 1rem',
+                                                borderRadius: 'var(--radius)',
+                                                background: 'var(--warning-50, #fffbeb)',
+                                                border: '1px solid var(--warning, #d97706)',
+                                                fontSize: '0.8125rem',
+                                                color: 'var(--warning, #d97706)',
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                gap: '0.5rem',
+                                            }}>
+                                                <FiAlertCircle size={14} />
+                                                You listed this auction and cannot place a bid on it.
+                                            </div>
+                                        ) : userCurrentBid?.status === 'WINNING' ? (
+                                            /* Already highest bidder — no point showing the form */
+                                            <div style={{
+                                                padding: '0.75rem 1rem',
+                                                borderRadius: 'var(--radius)',
+                                                background: 'var(--primary-50)',
+                                                border: '1px solid var(--primary-light)',
+                                                fontSize: '0.8125rem',
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                gap: '0.5rem',
+                                                color: 'var(--primary)',
+                                            }}>
+                                                <FiCheckCircle size={14} />
+                                                You are currently the highest bidder at {formatNaira(userCurrentBid.amount)}. You're winning!
+                                            </div>
+                                        ) : (
+                                            <>
                                         {/* User's current bid indicator */}
                                         {userCurrentBid && (
                                             <div style={{
@@ -733,14 +767,15 @@ export default function AuctionDetailPage() {
                                                 placeBidMutation.isPending ||
                                                 !bidAmount ||
                                                 Number(bidAmount) < minBid ||
-                                                (walletBalance !== null && walletBalance < Number(bidAmount)) ||
-                                                user?.id === seller?.id
+                                                (walletBalance !== null && walletBalance < Number(bidAmount))
                                             }
                                             onClick={() => placeBidMutation.mutate(Number(bidAmount))}
                                             style={{ marginTop: '0.75rem' }}
                                         >
                                             {placeBidMutation.isPending ? 'Placing Bid…' : bidSuccess ? 'Bid Placed! ✓' : 'Place Bid'}
                                         </button>
+                                            </>
+                                        )}
                                     </div>
                                 ) : (
                                     <div className="adp__login-prompt" id="login-to-bid">

--- a/frontend/src/pages/auth/RegisterPage.jsx
+++ b/frontend/src/pages/auth/RegisterPage.jsx
@@ -52,10 +52,17 @@ export default function RegisterPage() {
             let errorMessage = 'Registration failed. Try again.';
             if (err.response?.data) {
                 const errorData = err.response.data;
-                if (errorData.message) errorMessage = errorData.message;
-                else if (typeof errorData.detail === 'string') errorMessage = errorData.detail;
-                else if (errorData.detail?.message) errorMessage = errorData.detail.message;
-                else if (Array.isArray(errorData.detail)) errorMessage = errorData.detail.map(e => e.msg).join(', ');
+                if (Array.isArray(errorData.details) && errorData.details.length > 0) {
+                    errorMessage = errorData.details.map(e => e.message.replace(/^Value error,\s*/i, '')).join(', ');
+                } else if (errorData.message) {
+                    errorMessage = errorData.message;
+                } else if (typeof errorData.detail === 'string') {
+                    errorMessage = errorData.detail;
+                } else if (errorData.detail?.message) {
+                    errorMessage = errorData.detail.message;
+                } else if (Array.isArray(errorData.detail)) {
+                    errorMessage = errorData.detail.map(e => e.msg).join(', ');
+                }
             }
             setApiError(errorMessage);
         } finally {

--- a/frontend/src/pages/auth/ResetPasswordPage.jsx
+++ b/frontend/src/pages/auth/ResetPasswordPage.jsx
@@ -43,7 +43,18 @@ export default function ResetPasswordPage() {
       setTimeout(() => navigate('/login'), 3000);
     } catch (err) {
       setStatus('error');
-      setMessage(err.response?.data?.detail || 'Failed to reset password. The link may be expired.');
+      const errorData = err.response?.data;
+      let msg = 'Failed to reset password. The link may be expired.';
+      if (errorData) {
+        if (Array.isArray(errorData.details) && errorData.details.length > 0) {
+          msg = errorData.details.map(e => e.message.replace(/^Value error,\s*/i, '')).join(', ');
+        } else if (errorData.message) {
+          msg = errorData.message;
+        } else if (typeof errorData.detail === 'string') {
+          msg = errorData.detail;
+        }
+      }
+      setMessage(msg);
     }
   };
 


### PR DESCRIPTION
- Revert email implementation from Brevo HTTP API back to FastAPI-Mail with SMTP
- Add get_mail_config() and get_mail_client() helper functions for centralized mail configuration
- Update email settings to support both development (Mailtrap) and production SMTP servers
- Change mail_starttls to True and mail_ssl_tls to False for standard SMTP configuration
- Remove Brevo-specific API key configuration from settings
- Update send_email() to use FastAPI-Mail MessageSchema instead of Brevo HTTP payload
- Add auction detail page validation to prevent sellers from bidding on their own auctions
- Display warning message when seller attempts to place bid on their listing
- Show success message when user is already the highest bidder
- Update password reset and registration pages with improved form handling