### PR TITLE
feat(notifications,profile): add seller order cancellation notificati…

### DIFF
--- a/backend/apps/notifications/tasks.py
+++ b/backend/apps/notifications/tasks.py
@@ -583,6 +583,43 @@ def notify_order_cancelled_buyer(
 
 
 @celery.task(bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=3)
+def notify_order_cancelled_seller(
+    self, seller_email: str, seller_name: str, order_id: str
+):
+    """Notify seller that their order was cancelled due to non-shipment.
+
+    Args:
+        self: Celery task instance (injected via ``bind=True``).
+        seller_email: The seller's email address.
+        seller_name: The seller's name for personalisation.
+        order_id: UUID string of the order.
+
+    """
+    body = (
+        f"Hello {seller_name},\n\n"
+        f"Your order has been cancelled due to non-shipment within the deadline.\n\n"
+        f"Please ensure you ship items promptly to avoid future cancellations.\n\n"
+        f"View your orders: {settings.app_url}/my-orders"
+    )
+    try:
+        asyncio.run(
+            send_email(
+                subject="Order cancelled due to non-shipment",
+                recipients=[seller_email],
+                body=body,
+            )
+        )
+        logger.info("Order cancelled (seller) notification sent to %s", seller_email)
+    except Exception as exc:
+        logger.error(
+            "Failed to send order cancelled (seller) notification to %s: %s",
+            seller_email,
+            exc,
+        )
+        raise exc
+
+
+@celery.task(bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=3)
 def notify_dispute_raised_seller(
     self,
     seller_email: str,

--- a/frontend/src/components/profile/BankDetailsSection.jsx
+++ b/frontend/src/components/profile/BankDetailsSection.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { useQueryClient } from '@tanstack/react-query';
 import apiClient from '../../api/client';
 import { useToast } from '../../components/common/Toast';
 import { FiChevronDown, FiChevronUp, FiCreditCard, FiHash, FiUser, FiSave, FiX } from 'react-icons/fi';
@@ -16,6 +17,7 @@ export default function BankDetailsSection({ profile, onUpdate }) {
     const [isEditing, setIsEditing] = useState(false);
     const [isOpen, setIsOpen] = useState(false);
     const { showToast } = useToast();
+    const queryClient = useQueryClient();
 
     const bankDetails = profile.profile || {};
     const hasBankDetails = bankDetails.account_number && bankDetails.bank_code;
@@ -33,6 +35,7 @@ export default function BankDetailsSection({ profile, onUpdate }) {
             await apiClient.patch('/users/me', data);
             showToast('Bank details updated successfully!', 'success');
             setIsEditing(false);
+            queryClient.invalidateQueries({ queryKey: ['userProfile'] });
             if (onUpdate) onUpdate();
         } catch (error) {
             const msg = error.response?.data?.detail || 'Failed to update bank details';

--- a/frontend/src/pages/profile/MyProfilePage.jsx
+++ b/frontend/src/pages/profile/MyProfilePage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useForm } from 'react-hook-form';
+import { useQueryClient } from '@tanstack/react-query';
 import apiClient from "../../api/client";
 import { useToast } from "../../components/common/Toast";
 import BankDetailsSection from "../../components/profile/BankDetailsSection";
@@ -17,6 +18,7 @@ export default function MyProfilePage() {
     const [editing, setEditing] = useState(false);
     const { showToast } = useToast();
     const { register, handleSubmit, reset } = useForm();
+    const queryClient = useQueryClient();
 
     useEffect(() => { fetchProfile(); }, []);
 
@@ -45,6 +47,7 @@ export default function MyProfilePage() {
             await fetchProfile();
             setEditing(false);
             showToast('Profile updated successfully!', 'success');
+            queryClient.invalidateQueries({ queryKey: ['userProfile'] });
         } catch (error) {
             showToast('Failed to update profile', 'error');
         }


### PR DESCRIPTION
…on and cache invalidation

- Add notify_order_cancelled_seller Celery task to notify sellers of non-shipment cancellations
- Implement email notification with order cancellation reason and link to orders page
- Add query client cache invalidation in BankDetailsSection after bank details update
- Add query client cache invalidation in MyProfilePage after profile update
- Ensures profile data stays synchronized across components after mutations