### PR TITLE
fix(auth): improve token refresh handling and prevent refresh token loss

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -42,10 +42,11 @@ apiClient.interceptors.response.use(
                     refresh_token: refreshToken,
                 });
 
-                const { access_token, refresh_token, user } = response.data;
+                const { access_token, refresh_token: new_refresh_token } = response.data;
+                const { user, refreshToken: currentRefreshToken } = useAuthStore.getState();
 
-                // Save the new tokens to the global store
-                setAuth(user, access_token, refresh_token);
+                // Save the new tokens — keep existing refresh token if backend doesn't rotate
+                setAuth(user, access_token, new_refresh_token || currentRefreshToken);
 
                 // Retry the original request with the NEW token
                 originalRequest.headers.Authorization = `Bearer ${access_token}`;


### PR DESCRIPTION
- Destructure refresh token response with alias to avoid shadowing
- Preserve existing refresh token if backend doesn't return new one during rotation
- Retrieve current refresh token from auth store for fallback comparison
- Update token storage logic to handle optional refresh token rotation
- Prevent accidental loss of valid refresh tokens on incomplete backend responses