### PR TITLE
Remove volume mappings from docker-compose services

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -30,8 +30,6 @@ services:
     build: .
     ports:
       - "2102:8000"
-    volumes:
-      - .:/app
     depends_on:
       db:
         condition: service_healthy
@@ -42,7 +40,7 @@ services:
     dns:
       - 8.8.8.8
       - 8.8.4.4
-    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+    # command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 
   celery_worker:
     build: .
@@ -53,8 +51,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    volumes:
-      - .:/app
     dns:
       - 8.8.8.8
       - 8.8.4.4
@@ -69,8 +65,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    volumes:
-      - .:/app
     command: celery -A config.celery_app beat --loglevel=info
 
 volumes:


### PR DESCRIPTION
Removed volume mappings for app and celery services in docker-compose.